### PR TITLE
Fix compiling on macOS Sierra

### DIFF
--- a/src/macosx/EmulationOutlineView.m
+++ b/src/macosx/EmulationOutlineView.m
@@ -40,7 +40,7 @@
 
     NSAssert([windowController isKindOfClass:[EmulationWindowController class]],
              @"Expected windowController to be an instance of %@",
-             [EmulationWindowController class]);
+             NSStringFromClass([EmulationWindowController class]));
 
     [windowController delete:sender];
 }

--- a/src/macosx/EmulationOutlineView.m
+++ b/src/macosx/EmulationOutlineView.m
@@ -12,6 +12,8 @@
 #import "EmulationOutlineCell.h"
 #import "EmulationItem.h"
 
+#import "EmulationWindowController.h"
+
 @implementation EmulationOutlineView
 
 - (id)initWithCoder:(NSCoder *)decoder
@@ -34,7 +36,13 @@
 
 - (IBAction)delete:(id)sender
 {
-    return [[[self window] windowController] delete:sender];
+    EmulationWindowController *windowController = (EmulationWindowController *)[[self window] windowController];
+
+    NSAssert([windowController isKindOfClass:[EmulationWindowController class]],
+             @"Expected windowController to be an instance of %@",
+             [EmulationWindowController class]);
+
+    [windowController delete:sender];
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent *)theEvent

--- a/src/macosx/EmulationWindowController.h
+++ b/src/macosx/EmulationWindowController.h
@@ -60,6 +60,7 @@ NSOutlineViewDataSource, NSComboBoxDataSource>
 - (BOOL)doUnmount:(EmulationItem *)item;
 - (IBAction)showInFinder:(id)sender;
 - (IBAction)showDevice:(id)sender;
+- (IBAction)delete:(id)sender;
 
 - (BOOL)connect:(NSString *)thePath
           label:(NSString *)theLabel


### PR DESCRIPTION
As discussed in #12, there are issues when compiling under macOS Sierra (10.12). The main show-stopper here is `-[EmulationOutlineView delete:]`, which tries to call `-delete` on its `window`'s `windowController` without being aware of its type. This produces an error when building with the latest macOS SDK.

I've fixed this by casting `windowController` to the appropriate type (`EmulationWindowController`), and have added an assert enforcing this requirement.
